### PR TITLE
Rename html* for HTML*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Actions Status](https://github.com/mirego/html_test_identifiers/workflows/CI/badge.svg?branch%3Amaster)](https://github.com/mirego/html_test_identifiers/actions)
 
-# HtmlTestIdentifiers
+# HTMLTestIdentifiers
 
 Provides the basic functionality to add `data-testid` attribute depending on configuration.
 
@@ -9,40 +9,40 @@ Provides the basic functionality to add `data-testid` attribute depending on con
 Add the following to your config files if you want `data-testid` included in your release :
 
 ```elixir
-config :html_test_identifiers, provider: HtmlTestIdentifiers.TestID
+config :html_test_identifiers, provider: HTMLTestIdentifiers.TestID
 ```
 
 Add the following to your config files if you don't want `data_testid` attribute to be included in your release :
 
 ```elixir
-config :html_test_identifiers, provider: HtmlTestIdentifiers.NoTestID
+config :html_test_identifiers, provider: HTMLTestIdentifiers.NoTestID
 ```
 
-If there is no configuration, `HtmlTestIdentifiers.NoTestID` will be used by default
+If there is no configuration, `HTMLTestIdentifiers.NoTestID` will be used by default
 
 ## Examples
 
-    with `config :html_test_identifiers, provider: HtmlTestIdentifiers.TestID`
+    with `config :html_test_identifiers, provider: HTMLTestIdentifiers.TestID`
 
-    HtmlTestIdentifiers.testid_attribute("hello")
+    HTMLTestIdentifiers.testid_attribute("hello")
     # => "data-testid=\"hello\"
 
-    HtmlTestIdentifiers.testid_key("hello")
+    HTMLTestIdentifiers.testid_key("hello")
     # => "hello"
 
-    with `config :html_test_identifiers, provider: HtmlTestIdentifiers.NoTestID`
+    with `config :html_test_identifiers, provider: HTMLTestIdentifiers.NoTestID`
 
-    HtmlTestIdentifiers.testid_attribute("hello")
+    HTMLTestIdentifiers.testid_attribute("hello")
     # => nil
 
-    HtmlTestIdentifiers.testid_key("hello")
+    HTMLTestIdentifiers.testid_key("hello")
     # => nil
 
 ## Usages
 
 ```elixir
 defmodule MyView do
-  import HtmlTestIdentifiers
+  import HTMLTestIdentifiers
 end
 ```
 
@@ -53,14 +53,14 @@ Considering `.eex` file content
 <%= content_tag :p, "paragraph text content", data_testid: testid_key("paragraph-id") %>
 ```
 
-with `config :html_test_identifiers, provider: HtmlTestIdentifiers.TestID`, resulting HTML will be
+with `config :html_test_identifiers, provider: HTMLTestIdentifiers.TestID`, resulting HTML will be
 
 ```html
 <h1 data-testid="title-id">Title</h1>
 <p data-testid="paragraph-id">paragraph text content</p>
 ```
 
-with `config :html_test_identifiers, provider: HtmlTestIdentifiers.NoTestID`, resulting HTML will be
+with `config :html_test_identifiers, provider: HTMLTestIdentifiers.NoTestID`, resulting HTML will be
 
 ```html
 <h1>Title</h1>

--- a/lib/html_test_identifiers.ex
+++ b/lib/html_test_identifiers.ex
@@ -1,32 +1,32 @@
-defmodule HtmlTestIdentifiers do
+defmodule HTMLTestIdentifiers do
   @moduledoc """
   Provides the basic functionality to add `data-testid` attribute depending on configuration.
 
   ## Configuration
   Add the following to your config files if you want `data-testid` included in your release :
-      config :html_test_identifiers, provider: HtmlTestIdentifiers.TestID
+      config :html_test_identifiers, provider: HTMLTestIdentifiers.TestID
 
   Add the following to your config files if you don't want `data_testid` attribute to be included in your release :
-      config :html_test_identifiers, provider: HtmlTestIdentifiers.NoTestID
+      config :html_test_identifiers, provider: HTMLTestIdentifiers.NoTestID
 
-  If there is no configuration, `HtmlTestIdentifiers.NoTestID` will be used by default
+  If there is no configuration, `HTMLTestIdentifiers.NoTestID` will be used by default
 
   ## Examples
 
-      with `config :html_test_identifiers, provider: HtmlTestIdentifiers.TestID`
+      with `config :html_test_identifiers, provider: HTMLTestIdentifiers.TestID`
 
-      HtmlTestIdentifiers.testid_attribute("hello")
+      HTMLTestIdentifiers.testid_attribute("hello")
       # => "data-testid=\"hello\"
 
-      HtmlTestIdentifiers.testid_key("hello")
+      HTMLTestIdentifiers.testid_key("hello")
       # => "hello"
 
-      with `config :html_test_identifiers, provider: HtmlTestIdentifiers.NoTestID`
+      with `config :html_test_identifiers, provider: HTMLTestIdentifiers.NoTestID`
 
-      HtmlTestIdentifiers.testid_attribute("hello")
+      HTMLTestIdentifiers.testid_attribute("hello")
       # => nil
 
-      HtmlTestIdentifiers.testid_key("hello")
+      HTMLTestIdentifiers.testid_key("hello")
       # => nil
 
   """
@@ -40,7 +40,7 @@ defmodule HtmlTestIdentifiers do
         value
 
       :error ->
-        HtmlTestIdentifiers.NoTestID
+        HTMLTestIdentifiers.NoTestID
     end
   end
 end

--- a/lib/html_test_identifiers/no_test_id.ex
+++ b/lib/html_test_identifiers/no_test_id.ex
@@ -1,4 +1,4 @@
-defmodule HtmlTestIdentifiers.NoTestID do
+defmodule HTMLTestIdentifiers.NoTestID do
   @moduledoc """
     All functions return nil
   """

--- a/lib/html_test_identifiers/test_id.ex
+++ b/lib/html_test_identifiers/test_id.ex
@@ -1,4 +1,4 @@
-defmodule HtmlTestIdentifiers.TestID do
+defmodule HTMLTestIdentifiers.TestID do
   @moduledoc """
     Functions which returns key or attribute with key
   """

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule HtmlTestIdentifiers.MixProject do
+defmodule HTMLTestIdentifiers.MixProject do
   use Mix.Project
 
   def project do

--- a/test/html_test_identifiers_test.exs
+++ b/test/html_test_identifiers_test.exs
@@ -1,34 +1,34 @@
-defmodule HtmlTestIdentifiersTest do
+defmodule HTMLTestIdentifiersTest do
   use ExUnit.Case
 
-  import HtmlTestIdentifiersTest.Environment
+  import HTMLTestIdentifiersTest.Environment
 
   describe "TestID is configured" do
     setup do
-      modify_env(:html_test_identifiers, provider: HtmlTestIdentifiers.TestID)
+      modify_env(:html_test_identifiers, provider: HTMLTestIdentifiers.TestID)
       :ok
     end
 
     test "testid_attribute/1" do
-      assert HtmlTestIdentifiers.testid_attribute("hello") === {:safe, "data-testid=\"hello\""}
+      assert HTMLTestIdentifiers.testid_attribute("hello") === {:safe, "data-testid=\"hello\""}
     end
 
     test "testid_key/1" do
-      assert HtmlTestIdentifiers.testid_key("hello") === "hello"
+      assert HTMLTestIdentifiers.testid_key("hello") === "hello"
     end
   end
 
   describe "NoTestID is configured" do
     setup do
-      modify_env(:html_test_identifiers, provider: HtmlTestIdentifiers.NoTestID)
+      modify_env(:html_test_identifiers, provider: HTMLTestIdentifiers.NoTestID)
     end
 
     test "testid_attribute/1" do
-      assert is_nil(HtmlTestIdentifiers.testid_attribute("hello"))
+      assert is_nil(HTMLTestIdentifiers.testid_attribute("hello"))
     end
 
     test "testid_key/1" do
-      assert is_nil(HtmlTestIdentifiers.testid_key("hello"))
+      assert is_nil(HTMLTestIdentifiers.testid_key("hello"))
     end
   end
 end

--- a/test/support/environment.exs
+++ b/test/support/environment.exs
@@ -1,4 +1,4 @@
-defmodule HtmlTestIdentifiersTest.Environment do
+defmodule HTMLTestIdentifiersTest.Environment do
   def modify_env(app, overrides) do
     original_env = Application.get_all_env(app)
     Enum.each(overrides, fn {key, value} -> Application.put_env(app, key, value) end)


### PR DESCRIPTION
## 📖 Description and reason

Rename `html*` for `HTML*`