### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,7 @@
 ## 🎉 Result
 
 <!-- What is the result? Include screenshots if necessary. -->
+
+## 🦀 Dispatch
+
+`#dispatch/elixir`


### PR DESCRIPTION
## 📖 Description and reason

We update the template with Dispatch stack preset. We deprecated the `?stacks=` param in the webhook a while ago.