### PR TITLE
Update return of testid-attribute function

### DIFF
--- a/lib/html_test_identifiers.ex
+++ b/lib/html_test_identifiers.ex
@@ -16,7 +16,7 @@ defmodule HTMLTestIdentifiers do
       with `config :html_test_identifiers, provider: HTMLTestIdentifiers.TestID`
 
       HTMLTestIdentifiers.testid_attribute("hello")
-      # => "data-testid=\"hello\""
+      # =>  %{"data-testid" => "hello"}
 
       HTMLTestIdentifiers.testid_key("hello")
       # => "hello"

--- a/lib/html_test_identifiers/test_id.ex
+++ b/lib/html_test_identifiers/test_id.ex
@@ -4,7 +4,7 @@ defmodule HTMLTestIdentifiers.TestID do
   """
 
   def testid_attribute(key) do
-    {:safe, ~s(data-testid="#{key}")}
+    %{"data-testid" => "#{key}"}
   end
 
   def testid_key(key), do: key

--- a/test/html_test_identifiers_test.exs
+++ b/test/html_test_identifiers_test.exs
@@ -10,7 +10,7 @@ defmodule HTMLTestIdentifiersTest do
     end
 
     test "testid_attribute/1" do
-      assert HTMLTestIdentifiers.testid_attribute("hello") === {:safe, "data-testid=\"hello\""}
+      assert HTMLTestIdentifiers.testid_attribute("hello") === %{"data-testid" => "hello"}
     end
 
     test "testid_key/1" do


### PR DESCRIPTION
## 📖 Description and reason

With previous version we use it in phoenix html files as 
```elixir
<p <%= testid_attribute("paragraph-id") %>> my paragraph </p>
```

But with the new Phoenix version we will have following error, so we refactor to be used as

```elixir
<p {testid_attribute("paragraph-id")}> my paragraph </p>
```

```
** (Phoenix.LiveView.HTMLTokenizer.ParseError) ... : expected closing `>` or `/>`

Make sure the tag is properly closed. This may happen if there
is an EEx interpolation inside a tag, which is not supported.
For instance, instead of

    <div id="<%= @id %>">Content</div>

do

    <div id={@id}>Content</div>

If @id is nil or false, then no attribute is sent at all.

Inside {...} you can place any Elixir expression. If you want
to interpolate in the middle of an attribute value, instead of

    <a class="foo bar <%= @class %>">Text</a>

you can pass an Elixir string with interpolation:

    <a class={"foo bar #{@class}"}>Text</a>
```

## 🦀 Dispatch

`#dispatch/elixir`
